### PR TITLE
fix: update to work with v25

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -110,6 +110,7 @@ in
           "uptrack.service"
         ];
         RefuseManualStop = "yes";
+        StartLimitInterval = "90";
       };
       serviceConfig = {
         Type = "exec";
@@ -119,7 +120,6 @@ in
         WatchdogSec = "30s";
         Restart = "always";
         RestartSec = "4";
-        StartLimitIntervalSec = "90";
         StartLimitBurst = "4";
         MemoryMax = "18446744073709543424";
         ExecStop = "${cfg.package}/bin/sentinelctl control stop";

--- a/module.nix
+++ b/module.nix
@@ -109,20 +109,20 @@ in
           "uptrack-prefetch.service"
           "uptrack.service"
         ];
-        StartLimitInterval = "90";
-        StartLimitBurst = "4";
+        RefuseManualStop = "yes";
       };
       serviceConfig = {
-        Type = "forking";
-        ExecStart = "${cfg.package}/bin/sentinelctl control run";
+        Type = "exec";
+        ExecStart = "${cfg.package}/bin/sentinelone-agent";
         WorkingDirectory = "/opt/sentinelone/bin";
         SyslogIdentifier = "${cfg.dataDir}/log";
-        WatchdogSec = "5s";
+        WatchdogSec = "30s";
         Restart = "always";
         RestartSec = "4";
-        RefuseManualStop = "yes";
+        StartLimitIntervalSec = "90";
+        StartLimitBurst = "4";
         MemoryMax = "18446744073709543424";
-        ExecStop = "${cfg.package}/bin/sentinelctl control shutdown";
+        ExecStop = "${cfg.package}/bin/sentinelctl control stop";
         NotifyAccess = "all";
         KillMode = "process";
         TasksMax = "infinity";


### PR DESCRIPTION
A colleague shared their new systemd file which looks like this:

```
[Unit]
Description=Monitor SentinelOne Agent
After=uptrack-prefetch.service uptrack.service
RefuseManualStop=yes

[Service]
WorkingDirectory=/opt/sentinelone/bin
Type=exec
ExecStart=/opt/sentinelone/bin/sentinelone-agent
WatchdogSec=30s
Restart=on-failure

# NOTICE:
# 1) prefer StartLimitInterval on StartLimitIntervalSec since the last
#   is supported from systemd v230 and above.
# 2) following options are synchronized with similar parameters at sysvinit watchdog
#   this is to ensure similar behavior of systemd and sysvinit watcgdogs
StartLimitInterval=90
StartLimitBurst=4
RestartSec=4

# Enable memory accounting to create the cgroup files
MemoryAccounting=yes

ExecStop=/opt/sentinelone/bin/sentinelctl control stop
NotifyAccess=all

# Dont limit the maximum number of tasks that may be created
TasksMax=infinity

[Install]
WantedBy=multi-user.target
```
I believe I have made the appropriate changes to get this working. Marked as draft for the moment to test.