### PR TITLE
chore: make treefmt-nix optional

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1736143030,
@@ -34,34 +36,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1735554305,
-        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -71,7 +45,9 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1737483750,

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,16 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
-    treefmt-nix.url = "github:numtide/treefmt-nix";
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,8 @@
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
 
+    # Only used during development, can be disabled by flake users like this:
+    #   sentinelone.inputs.treefmt-nix.follows = "";
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -32,8 +34,7 @@
       {
         imports = [
           inputs.flake-parts.flakeModules.easyOverlay
-          inputs.treefmt-nix.flakeModule
-        ];
+        ] ++ (if inputs.treefmt-nix ? flakeModule then [ inputs.treefmt-nix.flakeModule ] else [ ]);
         systems = [
           "x86_64-linux"
         ];
@@ -45,14 +46,6 @@
             ...
           }:
           {
-            treefmt = {
-              programs.nixfmt = {
-                enable = true;
-                package = pkgs.nixfmt-rfc-style;
-              };
-              programs.mdformat.enable = true;
-            };
-
             overlayAttrs = {
               inherit (config.packages) sentinelone;
             };
@@ -69,6 +62,15 @@
                   inherit (self) nixosModules;
                 }
               );
+            };
+          }
+          // lib.optionalAttrs (inputs.treefmt-nix ? flakeModule) {
+            treefmt = {
+              programs.nixfmt = {
+                enable = true;
+                package = pkgs.nixfmt-rfc-style;
+              };
+              programs.mdformat.enable = true;
             };
           };
 


### PR DESCRIPTION
treefmt-nix is a development tool, and brings no benefit to users. Make it optional so users can disable it in their flakes in order to reduce the number of inputs.

Depends on https://github.com/devusb/sentinelone-nix/pull/7.