### PR TITLE
fix: Disable the patching of ELF files

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -52,6 +52,8 @@ stdenv.mkDerivation {
     ln -s $out/opt/sentinelone/lib $out/lib
   '';
 
+  dontPatchELF = true;
+
   preFixup = ''
     patchelf --replace-needed libelf.so.0 libelf.so $out/opt/sentinelone/lib/libbpf.so
   '';


### PR DESCRIPTION
Unless unset, nixpkgs builds will run patchelf automatically on installed ELF executables and libraries to remove unused directories from the RPATH, but this inevitably changes the checksum of the installed files.

When running version 25.1.3.6, startup was failing as the application runs an integrity check of its packaged libraries and found an invalid file signature when loading `libdfi.so`.

This change fixes that.