### PR TITLE
Bring sytemd options in line with SentinelOne 25.x

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -192,7 +192,6 @@ in
         Restart = "on-failure";
         RestartSec = "4";
         RefuseManualStop = "yes";
-        MemoryMax = "18446744073709543424";
         ExecStop = "${lib.getExe sentinelctlFhs} control stop";
         NotifyAccess = "all";
         TasksMax = "infinity";

--- a/module.nix
+++ b/module.nix
@@ -191,7 +191,6 @@ in
         WatchdogSec = "30s";
         Restart = "on-failure";
         RestartSec = "4";
-        RefuseManualStop = "yes";
         ExecStop = "${lib.getExe sentinelctlFhs} control stop";
         MemoryAccounting = "yes";
         NotifyAccess = "all";

--- a/module.nix
+++ b/module.nix
@@ -193,6 +193,7 @@ in
         RestartSec = "4";
         RefuseManualStop = "yes";
         ExecStop = "${lib.getExe sentinelctlFhs} control stop";
+        MemoryAccounting = "yes";
         NotifyAccess = "all";
         TasksMax = "infinity";
         BindPaths = [

--- a/module.nix
+++ b/module.nix
@@ -195,7 +195,6 @@ in
         MemoryMax = "18446744073709543424";
         ExecStop = "${lib.getExe sentinelctlFhs} control stop";
         NotifyAccess = "all";
-        KillMode = "process";
         TasksMax = "infinity";
         BindPaths = [
           "${cfg.dataDir}:/opt/sentinelone"

--- a/module.nix
+++ b/module.nix
@@ -188,7 +188,6 @@ in
         Type = "exec";
         ExecStart = "${cfg.package}/opt/sentinelone/bin/sentinelone-agent";
         WorkingDirectory = "/opt/sentinelone/bin";
-        SyslogIdentifier = "${cfg.dataDir}/log";
         WatchdogSec = "30s";
         Restart = "on-failure";
         RestartSec = "4";


### PR DESCRIPTION
As a follow-up to https://github.com/devusb/sentinelone-nix/pull/12, this brings the systemd options further in line with those in the systemd unit for version 25.x of SentinelOne. I have been with running these settings for several months without issue.

This includes the following changes (note that options removed are also not present in the upstream systemd unit):

* fix: Use the default SyslogIdentifier

  Having this set to the process name makes a little more sense than to the path
  in which additional logs can be found.

* fix: Unset `process` KillMode

  This is actively recommended against in the systemd.kill(5) man page.

* fix: Remove MemoryMax

  Given this is currently set to an obscenely high value, it's effectively like
  setting no limit.

* feat: Enable memory accounting

  This is set in the latest upstream service. It enables systemd to monitor and
  display metrics on memory usage.

* fix: Remove RefuseManualStop from service config

  This is duplicated, as it is already set correctly in the unitConfig.