### PR TITLE
Fix sentinelctl command

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -48,6 +48,10 @@ let
       chmod -R 0755 $(find ${cfg.dataDir} -group sentinelone)
     fi
   '';
+  sentinelctlFhs = pkgs.buildFHSEnv {
+    name = "sentinelctl";
+    runScript = "/opt/sentinelone/bin/sentinelctl";
+  };
 in
 {
   options = {
@@ -139,6 +143,7 @@ in
 
     environment.systemPackages = [
       cfg.package
+      sentinelctlFhs
     ];
 
     systemd.services.sentinelone = {
@@ -171,7 +176,7 @@ in
         RestartSec = "4";
         RefuseManualStop = "yes";
         MemoryMax = "18446744073709543424";
-        ExecStop = "${cfg.package}/bin/sentinelctl control stop";
+        ExecStop = "${lib.getExe sentinelctlFhs} control stop";
         NotifyAccess = "all";
         KillMode = "process";
         TasksMax = "infinity";

--- a/module.nix
+++ b/module.nix
@@ -168,7 +168,7 @@ in
       };
       serviceConfig = {
         Type = "exec";
-        ExecStart = "${cfg.package}/bin/sentinelone-agent";
+        ExecStart = "${cfg.package}/opt/sentinelone/bin/sentinelone-agent";
         WorkingDirectory = "/opt/sentinelone/bin";
         SyslogIdentifier = "${cfg.dataDir}/log";
         WatchdogSec = "30s";

--- a/package.nix
+++ b/package.nix
@@ -41,13 +41,8 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/opt/
-    mkdir -p $out/bin/
 
     cp -r opt/* $out/opt
-
-    ln -s $out/opt/sentinelone/bin/sentinelone-agent $out/bin/sentinelone-agent
-    ln -s $out/opt/sentinelone/bin/sentinelone-watchdog $out/bin/sentinelone-watchdog
-    ln -s $out/opt/sentinelone/lib $out/lib
   '';
 
   dontAutoPatchelf = true;

--- a/package.nix
+++ b/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation {
 
   installPhase = ''
     mkdir -p $out/opt/
-    mkdir -p $out/cfg/
     mkdir -p $out/bin/
 
     cp -r opt/* $out/opt

--- a/package.nix
+++ b/package.nix
@@ -45,15 +45,21 @@ stdenv.mkDerivation {
 
     cp -r opt/* $out/opt
 
-    ln -s $out/opt/sentinelone/bin/sentinelctl $out/bin/sentinelctl
     ln -s $out/opt/sentinelone/bin/sentinelone-agent $out/bin/sentinelone-agent
     ln -s $out/opt/sentinelone/bin/sentinelone-watchdog $out/bin/sentinelone-watchdog
     ln -s $out/opt/sentinelone/lib $out/lib
   '';
 
+  dontAutoPatchelf = true;
   dontPatchELF = true;
 
   preFixup = ''
     patchelf --replace-needed libelf.so.0 libelf.so $out/opt/sentinelone/lib/libbpf.so
+  '';
+
+  postFixup = ''
+    shopt -s extglob
+    addAutoPatchelfSearchPath $out/opt/sentinelone/lib
+    autoPatchelf $out/opt/sentinelone/!(bin) $out/opt/sentinelone/bin/!(sentinelctl)
   '';
 }


### PR DESCRIPTION
When `sentinelctl` is called, the agent runs checks against the binary to verify its integrity. The binary must be called from the correct path: `/opt/sentinelone/bin/sentinelctl`. The contents of the binary must also be as it expects, the binary is read directly as part of this process.

With autoPatchelf enabled by default, this causes the binaries interpreter and RPATH to be modified. As such this results in the integrity check failing, hence why `sentinelctl` commands currently fail.

Disables autoPatchelf for `sentinelctl` and wraps the command in an FHS environment.

Also tidies things up a little.