### PR TITLE
Make available in /opt

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -174,6 +174,7 @@ in
       "/opt/sentinelone/bin" = {
         device = "${cfg.package}/opt/sentinelone/bin";
         fsType = "none";
+        depends = [ "/opt/sentinelone" ];
         options = [
           "bind"
           "ro"
@@ -182,6 +183,7 @@ in
       "/opt/sentinelone/ebpfs" = {
         device = "${cfg.package}/opt/sentinelone/ebpfs";
         fsType = "none";
+        depends = [ "/opt/sentinelone" ];
         options = [
           "bind"
           "ro"
@@ -190,6 +192,7 @@ in
       "/opt/sentinelone/lib" = {
         device = "${cfg.package}/opt/sentinelone/lib";
         fsType = "none";
+        depends = [ "/opt/sentinelone" ];
         options = [
           "bind"
           "ro"
@@ -198,6 +201,7 @@ in
       "/opt/sentinelone/ranger" = {
         device = "${cfg.package}/opt/sentinelone/ranger";
         fsType = "none";
+        depends = [ "/opt/sentinelone" ];
         options = [
           "bind"
           "ro"

--- a/module.nix
+++ b/module.nix
@@ -153,7 +153,13 @@ in
     systemd.services.sentinelone-init = {
       wantedBy = [ "sentinelone.service" ];
       before = [ "sentinelone.service" ];
-      unitConfig.RequiresMountsFor = [ "/opt/sentinelone" ];
+      unitConfig.RequiresMountsFor = [
+        "/opt/sentinelone"
+        "/opt/sentinelone/bin"
+        "/opt/sentinelone/ebpfs"
+        "/opt/sentinelone/lib"
+        "/opt/sentinelone/ranger"
+      ];
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${getExe initScript}";

--- a/module.nix
+++ b/module.nix
@@ -153,6 +153,7 @@ in
     systemd.services.sentinelone-init = {
       wantedBy = [ "sentinelone.service" ];
       before = [ "sentinelone.service" ];
+      unitConfig.RequiresMountsFor = [ "/opt/sentinelone" ];
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${getExe initScript}";
@@ -163,6 +164,46 @@ in
       cfg.package
       sentinelctlScript
     ];
+
+    fileSystems = {
+      "/opt/sentinelone" = {
+        device = cfg.dataDir;
+        fsType = "none";
+        options = [ "bind" ];
+      };
+      "/opt/sentinelone/bin" = {
+        device = "${cfg.package}/opt/sentinelone/bin";
+        fsType = "none";
+        options = [
+          "bind"
+          "ro"
+        ];
+      };
+      "/opt/sentinelone/ebpfs" = {
+        device = "${cfg.package}/opt/sentinelone/ebpfs";
+        fsType = "none";
+        options = [
+          "bind"
+          "ro"
+        ];
+      };
+      "/opt/sentinelone/lib" = {
+        device = "${cfg.package}/opt/sentinelone/lib";
+        fsType = "none";
+        options = [
+          "bind"
+          "ro"
+        ];
+      };
+      "/opt/sentinelone/ranger" = {
+        device = "${cfg.package}/opt/sentinelone/ranger";
+        fsType = "none";
+        options = [
+          "bind"
+          "ro"
+        ];
+      };
+    };
 
     systemd.services.sentinelone = {
       enable = true;
@@ -183,6 +224,13 @@ in
         RefuseManualStop = "yes";
         StartLimitInterval = "90";
         StartLimitBurst = "4";
+        RequiresMountsFor = [
+          "/opt/sentinelone"
+          "/opt/sentinelone/bin"
+          "/opt/sentinelone/ebpfs"
+          "/opt/sentinelone/lib"
+          "/opt/sentinelone/ranger"
+        ];
       };
       serviceConfig = {
         Type = "exec";
@@ -195,14 +243,6 @@ in
         MemoryAccounting = "yes";
         NotifyAccess = "all";
         TasksMax = "infinity";
-        BindPaths = [
-          "${cfg.dataDir}:/opt/sentinelone"
-        ];
-        BindReadOnlyPaths = [
-          "${cfg.package}/opt/sentinelone/bin:/opt/sentinelone/bin"
-          "${cfg.package}/opt/sentinelone/ebpfs:/opt/sentinelone/ebpfs"
-          "${cfg.package}/opt/sentinelone/ranger:/opt/sentinelone/ranger"
-        ];
       };
       wantedBy = [ "multi-user.target" ];
     };


### PR DESCRIPTION
This fixes a sporadic error where it complains about not finding its binaries in `/opt`.

Disclaimer: this change was done with the help of Claude 5