### PR TITLE
Add check in configuration diretory to avoid issues with mounts

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -18,7 +18,7 @@ let
     mkdir -p ${cfg.dataDir}
 
     # initialize the data directory
-    if [ -z "$(ls -A ${cfg.dataDir} 2>/dev/null)" ]; then
+    if [ -z "$(ls -A ${cfg.dataDir}/configuration 2>/dev/null)" ]; then
       find "${cfg.package}/opt/sentinelone/" -mindepth 1 -maxdepth 1 ! -name "bin" ! -name "ebpfs" ! -name "ranger" -exec cp -r {} "${cfg.dataDir}/" \;
 
       cat << EOF > ${cfg.dataDir}/configuration/install_config


### PR DESCRIPTION
Recent change in adding mounts for impermanent setup broke the init script, which checks if there are any files in the dataDig directory, hence finding the mounts and not setting up the directory.

This PR changes the directroy for ${dataDig}/configuration, which only have a file if it is created by the setup script