### PR TITLE
fix: keep SentinelOne mounts out of fstab

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -150,16 +150,14 @@ in
     };
     users.groups.sentinelone = { };
 
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir} 0755 sentinelone sentinelone -"
+    ];
+
     systemd.services.sentinelone-init = {
       wantedBy = [ "sentinelone.service" ];
       before = [ "sentinelone.service" ];
-      unitConfig.RequiresMountsFor = [
-        "/opt/sentinelone"
-        "/opt/sentinelone/bin"
-        "/opt/sentinelone/ebpfs"
-        "/opt/sentinelone/lib"
-        "/opt/sentinelone/ranger"
-      ];
+      unitConfig.RequiresMountsFor = [ "/opt/sentinelone" ];
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${getExe initScript}";
@@ -171,49 +169,64 @@ in
       sentinelctlScript
     ];
 
-    fileSystems = {
-      "/opt/sentinelone" = {
-        device = cfg.dataDir;
-        fsType = "none";
-        options = [ "bind" ];
-      };
-      "/opt/sentinelone/bin" = {
-        device = "${cfg.package}/opt/sentinelone/bin";
-        fsType = "none";
-        depends = [ "/opt/sentinelone" ];
-        options = [
-          "bind"
-          "ro"
+    systemd.mounts = [
+      {
+        what = cfg.dataDir;
+        where = "/opt/sentinelone";
+        type = "none";
+        options = "bind";
+        wantedBy = [ "sentinelone-init.service" ];
+        before = [ "sentinelone-init.service" ];
+      }
+      {
+        what = "${cfg.package}/opt/sentinelone/bin";
+        where = "/opt/sentinelone/bin";
+        type = "none";
+        options = "bind,ro";
+        requires = [
+          "opt-sentinelone.mount"
+          "sentinelone-init.service"
         ];
-      };
-      "/opt/sentinelone/ebpfs" = {
-        device = "${cfg.package}/opt/sentinelone/ebpfs";
-        fsType = "none";
-        depends = [ "/opt/sentinelone" ];
-        options = [
-          "bind"
-          "ro"
+        after = [
+          "opt-sentinelone.mount"
+          "sentinelone-init.service"
         ];
-      };
-      "/opt/sentinelone/lib" = {
-        device = "${cfg.package}/opt/sentinelone/lib";
-        fsType = "none";
-        depends = [ "/opt/sentinelone" ];
-        options = [
-          "bind"
-          "ro"
+        wantedBy = [ "sentinelone.service" ];
+        before = [ "sentinelone.service" ];
+      }
+      {
+        what = "${cfg.package}/opt/sentinelone/ebpfs";
+        where = "/opt/sentinelone/ebpfs";
+        type = "none";
+        options = "bind,ro";
+        requires = [
+          "opt-sentinelone.mount"
+          "sentinelone-init.service"
         ];
-      };
-      "/opt/sentinelone/ranger" = {
-        device = "${cfg.package}/opt/sentinelone/ranger";
-        fsType = "none";
-        depends = [ "/opt/sentinelone" ];
-        options = [
-          "bind"
-          "ro"
+        after = [
+          "opt-sentinelone.mount"
+          "sentinelone-init.service"
         ];
-      };
-    };
+        wantedBy = [ "sentinelone.service" ];
+        before = [ "sentinelone.service" ];
+      }
+      {
+        what = "${cfg.package}/opt/sentinelone/ranger";
+        where = "/opt/sentinelone/ranger";
+        type = "none";
+        options = "bind,ro";
+        requires = [
+          "opt-sentinelone.mount"
+          "sentinelone-init.service"
+        ];
+        after = [
+          "opt-sentinelone.mount"
+          "sentinelone-init.service"
+        ];
+        wantedBy = [ "sentinelone.service" ];
+        before = [ "sentinelone.service" ];
+      }
+    ];
 
     systemd.services.sentinelone = {
       enable = true;

--- a/test.nix
+++ b/test.nix
@@ -40,6 +40,10 @@ pkgs.nixosTest {
     start_all()
 
     withoutCustomerId.wait_for_unit("sentinelone.service")
+    withoutCustomerId.succeed("mountpoint -q /opt/sentinelone")
+    withoutCustomerId.succeed("touch /opt/sentinelone/lib/.write-test && rm /opt/sentinelone/lib/.write-test")
+    withoutCustomerId.fail("touch /opt/sentinelone/bin/.write-test")
+    withoutCustomerId.fail("grep -q sentinelone /etc/fstab")
 
     withCustomerId.wait_for_unit("sentinelone.service")
 


### PR DESCRIPTION
Fixes #18

The `fileSystems` entries introduced by #16 generate boot-critical fstab mounts for paths inside the Nix store. During a generation switch, stale store paths can make `local-fs.target` fail and drop the system into emergency mode.

This change:

- Moves the SentinelOne bind mounts to service-scoped `systemd.mounts` units instead of `fileSystems`.
- Keeps `/opt/sentinelone` globally available for SentinelOne filesystem scanning.
- Keeps `bin`, `ebpfs`, and `ranger` read-only package mounts.
- Leaves `lib` in the writable data directory, since the agent writes runtime state there.
- Creates `dataDir` with tmpfiles before the writable bind mount is started.
- Preserves ordering between the writable data mount, initialization, read-only mounts, and the agent service.
- Adds VM assertions for writable `lib`, read-only `bin`, and the absence of SentinelOne fstab entries.

Validation:

- `nix fmt`
- `nix flake check --no-build --no-update-lock-file`
- Full VM test build was attempted, but the existing SentinelOne package source at `imugit.imubit.com` was unreachable from the test environment.
