### PR TITLE
fix: avoid mount ordering cycle

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -182,7 +182,7 @@ in
         what = "${cfg.package}/opt/sentinelone/bin";
         where = "/opt/sentinelone/bin";
         type = "none";
-        options = "bind,ro";
+        options = "bind,ro,nofail";
         requires = [
           "opt-sentinelone.mount"
           "sentinelone-init.service"
@@ -198,7 +198,7 @@ in
         what = "${cfg.package}/opt/sentinelone/ebpfs";
         where = "/opt/sentinelone/ebpfs";
         type = "none";
-        options = "bind,ro";
+        options = "bind,ro,nofail";
         requires = [
           "opt-sentinelone.mount"
           "sentinelone-init.service"
@@ -214,7 +214,7 @@ in
         what = "${cfg.package}/opt/sentinelone/ranger";
         where = "/opt/sentinelone/ranger";
         type = "none";
-        options = "bind,ro";
+        options = "bind,ro,nofail";
         requires = [
           "opt-sentinelone.mount"
           "sentinelone-init.service"

--- a/test.nix
+++ b/test.nix
@@ -44,6 +44,7 @@ pkgs.nixosTest {
     withoutCustomerId.succeed("touch /opt/sentinelone/lib/.write-test && rm /opt/sentinelone/lib/.write-test")
     withoutCustomerId.fail("touch /opt/sentinelone/bin/.write-test")
     withoutCustomerId.fail("grep -q sentinelone /etc/fstab")
+    withoutCustomerId.fail("journalctl -b --grep='ordering cycle' --quiet")
 
     withCustomerId.wait_for_unit("sentinelone.service")
 


### PR DESCRIPTION
The read-only bind mounts are wanted by `sentinelone.service`, which is part of `multi-user.target`. Without `nofail`, mount units gain implicit ordering before `local-fs.target`; this conflicts with their explicit ordering after `sentinelone-init.service` and creates a systemd ordering cycle.

Add `nofail` to suppress the implicit local-fs ordering while preserving the explicit SentinelOne service dependencies. Add a VM assertion to catch ordering-cycle regressions.

Validation:

- `nix fmt -- --ci .`
- `nix flake check --no-build --no-update-lock-file`
- `systemd-analyze verify` against the generated `knut` units reported no ordering cycle