### PR TITLE
Fix systemd ordering cycle

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -157,7 +157,6 @@ in
     systemd.services.sentinelone-init = {
       wantedBy = [ "sentinelone.service" ];
       before = [ "sentinelone.service" ];
-      unitConfig.RequiresMountsFor = [ "/opt/sentinelone" ];
       serviceConfig = {
         Type = "oneshot";
         ExecStart = "${getExe initScript}";
@@ -175,8 +174,6 @@ in
         where = "/opt/sentinelone";
         type = "none";
         options = "bind";
-        wantedBy = [ "sentinelone-init.service" ];
-        before = [ "sentinelone-init.service" ];
       }
       {
         what = "${cfg.package}/opt/sentinelone/bin";

--- a/module.nix
+++ b/module.nix
@@ -245,7 +245,6 @@ in
         StartLimitInterval = "90";
         StartLimitBurst = "4";
         RequiresMountsFor = [
-          "/opt/sentinelone"
           "/opt/sentinelone/bin"
           "/opt/sentinelone/ebpfs"
           "/opt/sentinelone/lib"

--- a/module.nix
+++ b/module.nix
@@ -12,6 +12,11 @@ let
       if cfg.email != null && cfg.serialNumber != null then "${cfg.email}-${cfg.serialNumber}" else null
     );
   hasCustomerId = customerId != null;
+  mountPaths = [
+    "bin"
+    "ebpfs"
+    "ranger"
+  ];
   initScript = pkgs.writeShellScriptBin "sentinelone-init.sh" ''
     #!/bin/bash
 
@@ -244,12 +249,7 @@ in
         RefuseManualStop = "yes";
         StartLimitInterval = "90";
         StartLimitBurst = "4";
-        RequiresMountsFor = [
-          "/opt/sentinelone/bin"
-          "/opt/sentinelone/ebpfs"
-          "/opt/sentinelone/lib"
-          "/opt/sentinelone/ranger"
-        ];
+        RequiresMountsFor = map (path: "/opt/sentinelone/${path}") mountPaths;
       };
       serviceConfig = {
         Type = "exec";

--- a/module.nix
+++ b/module.nix
@@ -30,8 +30,6 @@ let
       "opt-sentinelone.mount"
       "sentinelone-init.service"
     ];
-    wantedBy = [ "sentinelone.service" ];
-    before = [ "sentinelone.service" ];
   };
   initScript = pkgs.writeShellScriptBin "sentinelone-init.sh" ''
     #!/bin/bash

--- a/module.nix
+++ b/module.nix
@@ -17,6 +17,22 @@ let
     "ebpfs"
     "ranger"
   ];
+  mkBindMount = path: {
+    what = "${cfg.package}/opt/sentinelone/${path}";
+    where = "/opt/sentinelone/${path}";
+    type = "none";
+    options = "bind,ro";
+    requires = [
+      "opt-sentinelone.mount"
+      "sentinelone-init.service"
+    ];
+    after = [
+      "opt-sentinelone.mount"
+      "sentinelone-init.service"
+    ];
+    wantedBy = [ "sentinelone.service" ];
+    before = [ "sentinelone.service" ];
+  };
   initScript = pkgs.writeShellScriptBin "sentinelone-init.sh" ''
     #!/bin/bash
 
@@ -180,55 +196,8 @@ in
         type = "none";
         options = "bind";
       }
-      {
-        what = "${cfg.package}/opt/sentinelone/bin";
-        where = "/opt/sentinelone/bin";
-        type = "none";
-        options = "bind,ro";
-        requires = [
-          "opt-sentinelone.mount"
-          "sentinelone-init.service"
-        ];
-        after = [
-          "opt-sentinelone.mount"
-          "sentinelone-init.service"
-        ];
-        wantedBy = [ "sentinelone.service" ];
-        before = [ "sentinelone.service" ];
-      }
-      {
-        what = "${cfg.package}/opt/sentinelone/ebpfs";
-        where = "/opt/sentinelone/ebpfs";
-        type = "none";
-        options = "bind,ro";
-        requires = [
-          "opt-sentinelone.mount"
-          "sentinelone-init.service"
-        ];
-        after = [
-          "opt-sentinelone.mount"
-          "sentinelone-init.service"
-        ];
-        wantedBy = [ "sentinelone.service" ];
-        before = [ "sentinelone.service" ];
-      }
-      {
-        what = "${cfg.package}/opt/sentinelone/ranger";
-        where = "/opt/sentinelone/ranger";
-        type = "none";
-        options = "bind,ro";
-        requires = [
-          "opt-sentinelone.mount"
-          "sentinelone-init.service"
-        ];
-        after = [
-          "opt-sentinelone.mount"
-          "sentinelone-init.service"
-        ];
-        wantedBy = [ "sentinelone.service" ];
-        before = [ "sentinelone.service" ];
-      }
-    ];
+    ]
+    ++ map mkBindMount mountPaths;
 
     systemd.services.sentinelone = {
       enable = true;

--- a/module.nix
+++ b/module.nix
@@ -30,6 +30,11 @@ let
       "opt-sentinelone.mount"
       "sentinelone-init.service"
     ];
+    unitConfig = {
+      DefaultDependencies = "no";
+      Conflicts = "umount.target";
+      Before = "umount.target";
+    };
   };
   initScript = pkgs.writeShellScriptBin "sentinelone-init.sh" ''
     #!/bin/bash


### PR DESCRIPTION
* fix: Remove dependency on /opt/sentinelone bind mount for init script

  The script operates on the dataDir directly, it does not need to be bound to
  /opt/sentinelone to run.

* chore: Remove redundant /opt/sentinelone in RequiresMountsFor

  As per the systemd.unit(5) man page, it will automatically add dependencies on
  any mount units required to access the specified paths.

* chore: Map over list of mount paths to generate RequiresMountsFor


* chore: Generate child bind mounts from common attributes


* chore: Remove redundant statements from child bind mounts

  RequiredBy and Before dependencies are automatically added through the
  RequiresMountsFor directive on the sentinelone service.

* fix: Fix the ordering cycle by removing a dependency on local-fs.target

  As per the systemd.mount(5) man page, a Before= dependency on local-fs.target
  is added to mount units by default unless DefaultDependencies=no is set.
  Explicitly add Before= and Conflicts= on umount.target to ensure that they
  will continue to be stopped during shutdown.