### PR TITLE
ci: run the VM test in GitHub Actions via a stub agent package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            system-features = nixos-test benchmark big-parallel kvm
+      - name: Run flake checks
+        run: nix flake check -L

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -1,0 +1,27 @@
+name: update-flake-lock
+
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 8 * * 6'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v28
+        with:
+          token: ${{ secrets.FLAKE_LOCK_TOKEN || github.token }}
+          pr-title: "Update flake.lock" # Title of PR to be created
+          pr-labels: | # Labels to be set on the PR
+            dependencies
+            automated

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ result
 # We're waiting to see if its ok to distribute this
 *.deb
 .nixos-test-history
+.worktrees

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737632463,
-        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737483750,
-        "narHash": "sha256-5An1wq5U8sNycOBBg3nsDDgpwBmR9liOpDGlhliA6Xo=",
+        "lastModified": 1785945821,
+        "narHash": "sha256-NLSyTCW4K4ofhNBllt3omPasm6QpralXH1DBZOc91Dw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "f2cc121df15418d028a59c9737d38e3a90fbaf8f",
+        "rev": "ae7910970dddc408fe6ab1c8e4b277bb21d72dc0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,8 @@
       {
         imports = [
           inputs.flake-parts.flakeModules.easyOverlay
-        ] ++ (if inputs.treefmt-nix ? flakeModule then [ inputs.treefmt-nix.flakeModule ] else [ ]);
+        ]
+        ++ (if inputs.treefmt-nix ? flakeModule then [ inputs.treefmt-nix.flakeModule ] else [ ]);
         systems = [
           "x86_64-linux"
         ];
@@ -68,7 +69,7 @@
             treefmt = {
               programs.nixfmt = {
                 enable = true;
-                package = pkgs.nixfmt-rfc-style;
+                package = pkgs.nixfmt;
               };
               programs.mdformat.enable = true;
             };

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,12 @@
 
             packages = {
               sentinelone = pkgs.callPackage ./package.nix { };
+              # VM test using the real agent package, not publicly fetchable
+              vmtest = import ./test.nix {
+                inherit lib pkgs;
+                inherit (self) nixosModules;
+                stub = false;
+              };
             };
 
             checks = {

--- a/test.nix
+++ b/test.nix
@@ -19,7 +19,7 @@ aXRlX2tleSI6ICJmM2M4N2IyZTlhMWQ0YzZlIn0KCg==";
     };
   };
 in
-pkgs.nixosTest {
+pkgs.testers.nixosTest {
   name = "sentinelone";
   nodes = {
     withoutCustomerId = defaultTestAttrs;

--- a/test.nix
+++ b/test.nix
@@ -2,8 +2,21 @@
   lib,
   pkgs,
   nixosModules,
+  stub ? true,
 }:
 let
+  agentStub = pkgs.writeShellScript "sentinelone-agent" ''
+    while true; do
+      ${pkgs.systemd}/bin/systemd-notify WATCHDOG=1 || true
+      sleep 10
+    done
+  '';
+  # fake agent package providing everything module.nix expects from cfg.package
+  stubPackage = pkgs.runCommand "sentinelone-stub" { } ''
+    mkdir -p $out/opt/sentinelone/{bin,ebpfs,ranger,lib,configuration}
+    install -m 755 ${agentStub} $out/opt/sentinelone/bin/sentinelone-agent
+    install -m 755 ${pkgs.writeShellScript "sentinelctl" ""} $out/opt/sentinelone/bin/sentinelctl
+  '';
   defaultTestAttrs = {
     imports = [
       nixosModules.default
@@ -16,11 +29,12 @@ let
       # base64 encoded config with fake site key
       sentinelOneManagementTokenPath = pkgs.writeText "s1_token" "eyJ1cmwiOiAiaHR0cHM6Ly9zZW50aW5lbG9uZS1wcm9ncmFtLnNlbnRpbmVsb25lLm5ldCIsICJz
 aXRlX2tleSI6ICJmM2M4N2IyZTlhMWQ0YzZlIn0KCg==";
-    };
+    }
+    // lib.optionalAttrs stub { package = stubPackage; };
   };
 in
 pkgs.testers.nixosTest {
-  name = "sentinelone";
+  name = "sentinelone" + lib.optionalString stub "-stub";
   nodes = {
     withoutCustomerId = defaultTestAttrs;
 


### PR DESCRIPTION
The agent .deb is not publicly fetchable, so `nix flake check` could not
run for anyone without access to the private mirror — including CI. Checks
now default to a stub agent package that exercises the module's mount,
init, and unit wiring, with the real-agent test still available as
`packages.vmtest`. Adds a CI workflow running the checks on pushes and
PRs, a weekly flake.lock update PR, and the input bump that motivated it
(which itself needed the `testers.nixosTest` and `nixfmt` renames).