### PR TITLE
test: check for mount ordering cycles

### DIFF
--- a/test.nix
+++ b/test.nix
@@ -58,6 +58,7 @@ pkgs.testers.nixosTest {
     withoutCustomerId.succeed("touch /opt/sentinelone/lib/.write-test && rm /opt/sentinelone/lib/.write-test")
     withoutCustomerId.fail("touch /opt/sentinelone/bin/.write-test")
     withoutCustomerId.fail("grep -q sentinelone /etc/fstab")
+    withoutCustomerId.fail("journalctl -b --grep='ordering cycle' --quiet")
 
     withCustomerId.wait_for_unit("sentinelone.service")
 


### PR DESCRIPTION
Adds the missing regression assertion from #20: the VM journal must not report an ordering cycle during boot.